### PR TITLE
add admob sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OCR Android App using tesseract
 - [android-image-cropper](https://github.com/ArthurHub/Android-Image-Cropper): for image cropping.
 - [tess-two](https://github.com/rmtheis/tess-two): to recognize text (tesseract) and binarize (leptonica).
 - [firebase](https://firebase.google.com/docs/android/setup): to report metrics (for development purpose, you can [remove firebase dependencies](https://github.com/testica/text-scanner/pull/5) or add your own google-services.json).
-- [admob](https://developers.google.com/admob/android/quick-start): to show google ads (to can pay some bills). Check [PR #8](https://github.com/testica/text-scanner/pull/8) to know more about admob environment.
+- [admob](https://developers.google.com/admob/android/quick-start): to show google ads (to pay some bills). Check [PR #8](https://github.com/testica/text-scanner/pull/8) to know more about admob environment.
 
 ## Support
 - Android 4.0 +

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ OCR Android App using tesseract
 - [android-image-cropper](https://github.com/ArthurHub/Android-Image-Cropper): for image cropping.
 - [tess-two](https://github.com/rmtheis/tess-two): to recognize text (tesseract) and binarize (leptonica).
 - [firebase](https://firebase.google.com/docs/android/setup): to report metrics (for development purpose, you can [remove firebase dependencies](https://github.com/testica/text-scanner/pull/5) or add your own google-services.json).
+- [admob](https://developers.google.com/admob/android/quick-start): to show google ads (to can pay some bills). Check [PR #8](https://github.com/testica/text-scanner/pull/8) to know more about admob environment.
 
 ## Support
 - Android 4.0 +

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
 
         buildConfigField 'String', 'AdMobAppId', '"ca-app-pub-3940256099942544~3347511713"'
         resValue 'string', 'admob_app_id', '"ca-app-pub-3940256099942544~3347511713"'
-        resValue 'string', 'admob_unit_id', 'ca-app-pub-3940256099942544/6300978111"'
+        resValue 'string', 'admob_unit_id', '"ca-app-pub-3940256099942544/6300978111"'
     }
     buildTypes {
         release {
@@ -37,7 +37,7 @@ dependencies {
     implementation 'com.crashlytics.sdk.android:crashlytics:2.9.5'
     implementation 'com.rmtheis:tess-two:6.0.4'
     implementation 'com.theartofdev.edmodo:android-image-cropper:2.3.1'
-    implementation 'com.google.android.gms:play-services-ads:15.0.1'
+    implementation 'com.google.firebase:firebase-ads:15.0.1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,12 +11,19 @@ android {
         targetSdkVersion 26
         versionCode 3
         versionName "1.2"
+
+        buildConfigField 'String', 'AdMobAppId', '"ca-app-pub-3940256099942544~3347511713"'
+        resValue 'string', 'admob_app_id', '"ca-app-pub-3940256099942544~3347511713"'
+        resValue 'string', 'admob_unit_id', 'ca-app-pub-3940256099942544/6300978111"'
     }
     buildTypes {
         release {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            buildConfigField 'String', 'AdMobAppId', TextScanner_AdMobAppId
+            resValue 'string', 'admob_app_id', TextScanner_AdMobAppId
+            resValue 'string', 'admob_unit_id', TextScanner_AdMobUnitId
         }
     }
 }
@@ -26,10 +33,11 @@ dependencies {
     implementation 'junit:junit:4.12'
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:design:26.1.0'
-    implementation 'com.google.firebase:firebase-core:16.0.1'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.4'
+    implementation 'com.google.firebase:firebase-core:16.0.3'
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.5'
     implementation 'com.rmtheis:tess-two:6.0.4'
     implementation 'com.theartofdev.edmodo:android-image-cropper:2.3.1'
+    implementation 'com.google.android.gms:play-services-ads:15.0.1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -26,6 +27,10 @@
         <activity
             android:name=".Recognizer"
             android:configChanges="keyboardHidden|orientation|screenSize" />
+        <!-- Sample AdMob App ID: ca-app-pub-3940256099942544~3347511713 -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="@string/admob_app_id"/>
     </application>
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,6 @@
         <activity
             android:name=".Recognizer"
             android:configChanges="keyboardHidden|orientation|screenSize" />
-        <!-- Sample AdMob App ID: ca-app-pub-3940256099942544~3347511713 -->
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="@string/admob_app_id"/>

--- a/app/src/main/java/com/ltapps/textscanner/MainActivity.java
+++ b/app/src/main/java/com/ltapps/textscanner/MainActivity.java
@@ -17,6 +17,10 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.AdView;
+import com.google.android.gms.ads.MobileAds;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +30,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private Uri outputFileUri;
     private View mView;
     public final static String EXTRA_MESSAGE = "com.ltapps.textscanner.message";
+    private AdView mAdView;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -37,6 +43,12 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         mView = findViewById(R.id.mainView);
         mView.setOnClickListener(this);
 
+        // AdMob App ID
+        MobileAds.initialize(this, BuildConfig.AdMobAppId);
+        mAdView = findViewById(R.id.adView);
+        AdRequest adRequest = new AdRequest.Builder().build();
+        mAdView.loadAd(adRequest);
+
         if (ContextCompat.checkSelfPermission(this,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 != PackageManager.PERMISSION_GRANTED) {
@@ -45,7 +57,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             if (ActivityCompat.shouldShowRequestPermissionRationale(this,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
 
-                // Show an expanation to the user *asynchronously* -- don't block
+                // Show an explanation to the user *asynchronously* -- don't block
                 // this thread waiting for the user's response! After the user
                 // sees the explanation, try again to request the permission.
 

--- a/app/src/main/java/com/ltapps/textscanner/Recognizer.java
+++ b/app/src/main/java/com/ltapps/textscanner/Recognizer.java
@@ -27,6 +27,9 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.AdView;
+import com.google.android.gms.ads.MobileAds;
 import com.googlecode.tesseract.android.TessBaseAPI;
 
 import java.io.File;
@@ -44,6 +47,7 @@ public class Recognizer extends AppCompatActivity implements  Toolbar.OnMenuItem
     TessBaseAPI baseApi;
     AsyncTask<Void, Void, Void> copy = new copyTask();
     AsyncTask<Void, Void, Void> ocr = new ocrTask();
+    private AdView mAdView;
 
     private static final String DATA_PATH = Environment.getExternalStorageDirectory().getAbsolutePath() + "/com.ltapps.textscanner/";
 
@@ -51,6 +55,13 @@ public class Recognizer extends AppCompatActivity implements  Toolbar.OnMenuItem
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.recognizer);
+
+        // AdMob App ID
+        MobileAds.initialize(this, BuildConfig.AdMobAppId);
+        mAdView = findViewById(R.id.adView);
+        AdRequest adRequest = new AdRequest.Builder().build();
+        mAdView.loadAd(adRequest);
+
         toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         toolbar.setOnMenuItemClickListener(this);

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -36,4 +36,14 @@
             android:src="@drawable/camera"
             android:contentDescription="@string/camera" />
     </LinearLayout>
+    <com.google.android.gms.ads.AdView
+        xmlns:ads="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/adView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true"
+        ads:adSize="SMART_BANNER"
+        ads:adUnitId="@string/admob_unit_id">
+    </com.google.android.gms.ads.AdView>
 </RelativeLayout>

--- a/app/src/main/res/layout/recognizer.xml
+++ b/app/src/main/res/layout/recognizer.xml
@@ -43,5 +43,16 @@
         android:textSize="18sp"
         android:layout_below="@+id/extension" />
 
+    <com.google.android.gms.ads.AdView
+        xmlns:ads="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/adView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true"
+        ads:adSize="SMART_BANNER"
+        ads:adUnitId="@string/admob_unit_id">
+    </com.google.android.gms.ads.AdView>
+
 
 </RelativeLayout>

--- a/app/src/main/res/layout/recognizer.xml
+++ b/app/src/main/res/layout/recognizer.xml
@@ -54,5 +54,4 @@
         ads:adUnitId="@string/admob_unit_id">
     </com.google.android.gms.ads.AdView>
 
-
 </RelativeLayout>


### PR DESCRIPTION
For development purpose the project uses test keys suggested by [google doc](https://developers.google.com/admob/android/quick-start). But, for release mode (production) I used my hidden keys, you can do the same following this [post](https://medium.com/code-better/hiding-api-keys-from-your-android-repository-b23f5598b906).